### PR TITLE
Bump to 1.4.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,12 +192,12 @@ scc = lkocman
 [Project config]
 markdown_filename = project_config.md
 
-[Alpha phase]
+[Alpha Phase]
 Depends on = Project config
 markdown_filename = alpha.md
 
 [Alpha 1]
-Implements = Alpha phase
+Implements = Alpha Phase
 markdown_filename = repetitiveTasksForMilestones.md
 
 [Beta Phase]

--- a/example/alpha.md
+++ b/example/alpha.md
@@ -1,4 +1,4 @@
-# Alpha phase
+# Alpha Phase
 
 #### Beta flag
 Responsible: rel-mgmt 

--- a/example/my_project.conf
+++ b/example/my_project.conf
@@ -1,5 +1,7 @@
 [project]
-name = My cool product 1.0
+#name = My cool product 1.0
+name = SUSE Linux Enterprise Server 12 SP5
+
 
 [ownership]
 markdown_variable = Responsible
@@ -13,12 +15,12 @@ scc = lkocman
 [Project config]
 markdown_filename = project_config.md
 
-[Alpha phase]
+[Alpha Phase]
 Depends on = Project config
 markdown_filename = alpha.md
 
 [Alpha 1]
-Implements = Alpha phase
+Implements = Alpha Phase
 markdown_filename = repetitiveTasksForMilestones.md
 
 [Beta Phase]

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
         ("share/md2workflow/config", glob("config/*"))],
     setup_requires=[] + pytest_runner,
     tests_require=["pytest",],
-    install_requires=["jira",],
+    install_requires=["jira", "configparser"],
     entry_points = {
 	"console_scripts": [
     	"md2workflow = md2workflow.cli:main",

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
     name="md2workflow",
     description="Create a JIRA or other Workflow from markdown files.",
     long_description="Create a JIRA or other Workflow from markdown files.",
-    version="1.4.9",
+    version="1.4.10",
     license="GPLv3",
     author="Lubos Kocman",
     author_email="Lubos.Kocman@suse.com",

--- a/tests/test_markdown.py
+++ b/tests/test_markdown.py
@@ -174,7 +174,6 @@ def test_process_subtask():
     md = markdown.MarkDown()
     md.reads(raw)
     assert len(md.nodes) == 1 and isinstance(md.nodes[0], markdown.Heading1)
-    print "second", md.nodes[0].nodes
     assert len(md.nodes[0].nodes) == 1 and isinstance(
         md.nodes[0].nodes[0], markdown.Heading4)
     assert len(md.nodes[0].nodes[0].nodes) == 2


### PR DESCRIPTION
* fix test so it doesn't fail on python3
* fix invalid reference to Alpha phase in the example checklist
* add configparser as a runtime dependency as it has to be explicitly required at least for python2