### PR TITLE
Issue #11: Basic skeleton for Redmine backend (WORK IN PROGRESS)

### DIFF
--- a/bin/md2workflow
+++ b/bin/md2workflow
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # -*- coding: utf-8 -*-
 

--- a/config/redmine-example.conf
+++ b/config/redmine-example.conf
@@ -9,6 +9,10 @@ auth = basic
 # default user password in the redmine container was admin/admin (min. req for pass is 8 char)
 user = admin
 password = adminadmin
+# We'll create subproject if project is defined
+project = Example process 1.0
+short = ep-1.0
+is_project_public = True
 
 [logging]
 level = DEBUG

--- a/config/redmine-example.conf
+++ b/config/redmine-example.conf
@@ -1,0 +1,10 @@
+[global]
+# currently the only one supported
+backend = redmine
+
+[logging]
+level = DEBUG
+
+[TaskRelations]
+relations = Blocks, Depends On, Implements, Implemented by
+inbound = Implemented by, Depends On

--- a/config/redmine-example.conf
+++ b/config/redmine-example.conf
@@ -2,6 +2,14 @@
 # currently the only one supported
 backend = redmine
 
+[redmine]
+# lkocman's local container setup, default port is 3000
+server = http://redmine-example:3000
+auth = basic
+# default user password in the redmine container was admin/admin (min. req for pass is 8 char)
+user = admin
+password = adminadmin
+
 [logging]
 level = DEBUG
 

--- a/config/redmine-example.conf
+++ b/config/redmine-example.conf
@@ -10,8 +10,8 @@ auth = basic
 user = admin
 password = adminadmin
 # We'll create subproject if project is defined
-project = Example process 1.0
-short = ep-1.0
+# Identifier of parent process
+parent = example
 is_project_public = True
 
 [logging]

--- a/example/my_project.conf
+++ b/example/my_project.conf
@@ -1,7 +1,7 @@
 [project]
 name = Example product 1.0
 homepage = http://localhost
-short = ep-1.0
+identifier = example-product-1-0
 
 [ownership]
 markdown_variable = Responsible

--- a/example/my_project.conf
+++ b/example/my_project.conf
@@ -1,7 +1,7 @@
 [project]
-#name = My cool product 1.0
-name = SUSE Linux Enterprise Server 12 SP5
-
+name = Example product 1.0
+homepage = http://localhost
+short = ep-1.0
 
 [ownership]
 markdown_variable = Responsible

--- a/md2workflow/backend/jirabackend.py
+++ b/md2workflow/backend/jirabackend.py
@@ -101,7 +101,7 @@ class JiraSubTask(workflow.GenericTask):
     def set_action(self, action):
         if action not in (CliAction.CREATE, CliAction.UPDATE):
             raise ValueError(
-                "JiraBasedProject: unsupported action %s" % action)
+                "%s: unsupported action %s" % (self.__class__.__name__, action))
         self.action = action
 
     def _get_field(self, field_name):

--- a/md2workflow/backend/redminebackend.py
+++ b/md2workflow/backend/redminebackend.py
@@ -9,6 +9,7 @@ import md2workflow.workflow as workflow
 import md2workflow.markdown as markdown
 
 from md2workflow.cli import get_md_abspath
+from redminelib import Redmine
 
 
 class RedmineSubttask(workflow.GenericTask):

--- a/md2workflow/backend/redminebackend.py
+++ b/md2workflow/backend/redminebackend.py
@@ -5,29 +5,187 @@ import os
 import getpass
 import sys
 
+from redminelib import Redmine, exceptions
+
 import md2workflow.workflow as workflow
 import md2workflow.markdown as markdown
 
 from md2workflow.cli import get_md_abspath
-from redminelib import Redmine
+from md2workflow.cli import CliAction
 
 
-class RedmineSubtask(workflow.GenericTask):
-    def __init__(self, summary, client_session=None, description="", environment=None, conf=None):
-        super(RedmineSubtask, self).__init__(
+
+def str_to_bool(value):
+    return True if value.lower() == 'true' else False
+
+class RedmineSubTask(workflow.GenericTask):
+    def __init__(self, summary, client_session=None, description="",
+                    environment=None, conf=None):
+        super(RedmineSubTask, self).__init__(
             summary, description, environment, conf)
         self.client_session = client_session
         self._published = False
-        self._issue = None
+        self._redmine = None
         self._updatable = None
+        self.action = CliAction.CREATE # default
 
-class RedmineTask(RedmineSubtask, workflow.GenericNestedTask):
-    pass # Hackweek19 subject
+    def set_action(self, action):
+        if action not in (CliAction.CREATE, CliAction.UPDATE):
+            raise ValueError(
+                "%s: unsupported action %s" % (self.__class__.__name__, action))
+        self.action = action
+
+class RedmineTask(RedmineSubTask, workflow.GenericNestedTask):
+    def publish(self, force_publish=False):
+        if self.published: # Idempotency
+            return
+        self._redmine = self.client_session.issue.new()
+        self._redmine.subject = self.summary
+        self._redmine.description = self.description
+        # our parent would be a version, so let's go for parent of the version
+        #self._redmine.fixed_version_id = self.parent_task._redmine.id
+        #self._redmine.parent = self.parent_task.parent_task._redmine.id
+        self._redmine.project_id = self.parent_task.parent_task._redmine.id
+
+        # Following save requires Issue states, Issue Workflow and Issue Tracker
+        # to be set up manually. Unfortunatelly this can't be done over API
+        # However we can inherit it from the parent project.
+        # Users using fresh redmine container without configuration need to
+        # pre-configure the instance
+        # https://python-redmine.com/resources/tracker.html
+
+        # XXX: I see that some issues are multiplied perhaps we have to check
+        # Whether the issue was already published or not.s
+        self._redmine.save()
+
+    @property
+    def task_class(self):
+        return RedmineSubTask
+
+    def new_task(self, **kwargs):
+        """
+        Returns a new instance of class returned by task_class()
+        """
+        return self.task_class(client_session=self.client_session, environment=self.environment, conf=self.conf, **kwargs)
+
+
+    def add_task(self, task):
+        """
+        Args
+            task (RedmineSubTask instance)
+
+        Make sure to publish new Redmine Version (our Workflow)
+        on creation.
+        """
+        task.action = self.action # Make sure that tasks knows Update/Create
+        task.parent_task = self
+        task.logger = self.logger
+        super(RedmineTask, self).add_task(task)
+        task.publish() # there is nothing to wait for no pending task relations etc.
+
 
 class RedmineBasedWorkflow(RedmineTask, workflow.GenericWorkflow):
-    pass # Hackweek19 subject
+    """
+    Redmine version representation of our Workflow (e.g. EPIC in others)
+    """
+
+    @property
+    def task_class(self):
+        return RedmineTask
+
+    def publish(self, force_publish=False):
+        if self.published: # Idempotency
+            return
+        if self.action == CliAction.UPDATE:
+            all_versions = self.parent_task._redmine.versions
+            for ver in all_versions:
+                if ver.name == self.summary:
+                    self._redmine = self.client_session.version.get(ver.id)
+                    break
+
+        # Not --update, or the version was simply not created yet e.g. brand new one
+        if not self._redmine:
+            self._redmine = self.client_session.version.new()
+            self._redmine.project_id = self.parent_task._redmine.id
+            self._redmine.name = self.summary
+            self._redmine.status = 'open'
+            self._redmine.sharing = 'none'
+            #self._redmine.due_date = datetime.date(2014, 1, 30) # TODO Issue #17
+            self._redmine.description = self.description
+            self._redmine.wiki_page_title = self.summary
+            self._redmine.save()
+            self.logger.debug("New Redmine version (workflow) create id=%s" % self._redmine.id)
 
 class RedmineBasedProject(RedmineBasedWorkflow, workflow.GenericProject):
+    """
+    Redmine project representation of our Workflow Project
+    """
+
+    @property
+    def task_class(self):
+        return RedmineBasedWorkflow
+
+    def new_task(self, **kwargs):
+        """
+        Returns a new instance of class returned by task_class()
+        """
+        return self.task_class(client_session=self.client_session, environment=self.environment, conf=self.conf, **kwargs)
+
+
+    def add_task(self, task):
+        """
+        Args
+            task (RedmineSubTask instance)
+
+        Make sure to publish new Redmine Version (our Workflow)
+        on creation.
+        """
+        task.action = self.action # Make sure that tasks knows Update/Create
+        task.parent_task = self
+        task.logger = self.logger
+        super(RedmineBasedWorkflow, self).add_task(task)
+        task.publish() # there is nothing to wait for no pending task relations etc.
+
+    def publish(self, force_publish=False):
+        if self.published: # Idempotency
+            return
+        # Let's refer to all issue/project redmine representations as _redmnie in every class
+        if self.action == CliAction.UPDATE:
+            self.logger.debug("Update: Looking up Redmine project %s" % self.conf["project"]["identifier"])
+            self._redmine = self.client_session.project.get(self.conf["project"]["identifier"])
+            self.logger.debug("Update: Found Redmine project=%s id=%s" % (self._redmine, self._redmine.id))
+            return
+
+        self._redmine = self.client_session.project.new()
+        self._redmine.name = self.summary
+        self._redmine.identifier =  self.conf["project"]["identifier"]
+        self._redmine.description = self.description
+        self._redmine.is_public = str_to_bool(self.environment["redmine"]["is_project_public"])
+        self._redmine.inherit_members = True
+
+        # XXX: parent was not set
+        if "parent" in self.environment["redmine"]:
+            parent_id = self.environment["redmine"]["parent"]
+
+            self.logger.debug("Looking up Redmine parent project %s" % parent_id)
+            try:
+                parent = self.client_session.project.get(parent_id)
+                self._redmine.parent = parent.id
+                self.logger.debug("Found Redmine parent project=%s id=%s" % (parent, parent.id))
+            except exceptions.ResourceNotFoundError as e:
+                self.logger.error("Could not find Redmine parent project=%s" % parent_id)
+                raise e
+
+        if "homepage" in self.conf["project"]:
+            self._redmine.homepage=self.conf.get("project", "homepage")
+
+        # Publish
+        try:
+            self._redmine.save()
+        except exceptions.ForbiddenError:
+            self.logger.error("Unauthorized to create project %s. " \
+            "Is Redmine API enabled? Do you have role with permission to create project?" % self.summary)
+            raise
     def client_session_from_env(self):
         """
         This will be inherited to every added child task and it's child task ...
@@ -54,9 +212,9 @@ class RedmineBasedProject(RedmineBasedWorkflow, workflow.GenericProject):
                     "Password of Redmine user %s for %s: " % (user, server))
             self.logger.debug("Creating redmine session %s@%s" % (user, server))
             self.client_session = Redmine(
-                                                server,
-                                                username=user,
-                                                password=password)
+                                            server,
+                                            username=user,
+                                            password=password)
         else:
             raise NotImplementedError("Authentication type '%s' is not implemented." % \
                                         self.environment["redmine"]["auth"])
@@ -75,6 +233,8 @@ def handle_project(cli):
     project.logger = cli.logger
     project.conf = cli.project_conf
     project.client_session_from_env()
+    project.set_action(cli.action)
+    project.publish() # let's create redmine (sub) project
 
     for workflow_section in project.conf.sections():  # Workflow as in Milestone (e.g Beta) or Epic
         # these are not milestone sections

--- a/md2workflow/backend/redminebackend.py
+++ b/md2workflow/backend/redminebackend.py
@@ -1,0 +1,64 @@
+# -*- coding: utf-8 -*-
+
+import codecs
+import os
+import getpass
+import sys
+
+import md2workflow.workflow as workflow
+import md2workflow.markdown as markdown
+
+from md2workflow.cli import get_md_abspath
+
+
+class RedmineSubttask(workflow.GenericTask):
+    pass # Hackweek19 subject
+
+class RedmineTask(RedmineSubttask, workflow.GenericNestedTask):
+    pass # Hackweek19 subject
+
+class RedmineBasedWorkflow(RedmineTask, workflow.GenericWorkflow):
+    pass # Hackweek19 subject
+
+class RedmineBasedProject(RedmineBasedWorkflow, workflow.GenericProject):
+    pass # Hackweek19 subject
+
+def handle_project(cli):
+    """
+    Args:
+        cli (Cli) - an object representing execution environment
+    """
+    cli.logger.info(
+        "Using Redmine Backend.")
+    project = RedmineBasedProject(
+        summary=cli.project_conf["project"]["name"], environment=cli.environment, conf=cli.project_conf)
+    project.logger = cli.logger
+    project.conf = cli.project_conf
+
+    for workflow_section in project.conf.sections():  # Workflow as in Milestone (e.g Beta) or Epic
+        # these are not milestone sections
+        if workflow_section in ('project', 'ownership'):
+            continue
+
+        # this can be skipped for handling virtual milestones such as Public Beta,
+        # where the only purpose is to have a separate set of Milestone Tasks
+        # which are named differently
+        if 'markdown_filename' in project.conf[workflow_section]:
+            # section represents e.g. milestone1, order is important due Blocks/Depends On
+            project_relpath = project.conf[workflow_section]['markdown_filename']
+            md_path = get_md_abspath(cli.project_path, project_relpath)
+
+            cli.logger.debug("Processing %s" % md_path)
+            if not os.path.exists(md_path):
+                cli.logger.error("Referenced filename doesn't exist! relpath: %s abspath: %s" % (
+                    project_relpath, md_path))
+                sys.exit(3)
+
+            fd = codecs.open(md_path, encoding='utf-8')
+            md = markdown.MarkDown()
+            md.logger = cli.logger
+            md.read(fd)
+            project.from_markdown(md, override_workflow_name=workflow_section)
+            project.relations_from_conf_section(project.conf, workflow_section)
+
+    return True  # for testing purposes

--- a/md2workflow/cli.py
+++ b/md2workflow/cli.py
@@ -156,6 +156,9 @@ class Cli(object):
         elif backend == "generic":
             import md2workflow.backend.genericbackend
             md2workflow.backend.genericbackend.handle_project(self)
+        elif backend == "redmine":
+            import md2workflow.backend.redminebackend
+            md2workflow.backend.redminebackend.handle_project(self)
         else:
             logger.error("Backend %s is not supported." % backend)
             raise NotImplementedError("Backend %s is not supported." % backend)

--- a/md2workflow/cli.py
+++ b/md2workflow/cli.py
@@ -213,7 +213,6 @@ def main():
         print("ERROR: Found following md2workflow environment config issues:\n%s" % (
             "\n".join(environment_errors)))
         sys.exit(1)
-
     project_errors = Cli.validate_project(project_conf)
     if project_errors:
         print("ERROR: Found following md2workflow product issues:\n%s" %

--- a/md2workflow/validation/__init__.py
+++ b/md2workflow/validation/__init__.py
@@ -6,16 +6,43 @@ def allowed_section_keys(section, allowed_keys):
     Args
         section (ConfigParser[section])
         allowed_keys(list)
+
+    Returns list of errors (str) in case that section contains invalid keys
     """
     errors = []
+    ak = [k.lower() for k in allowed_keys]
     for key in section:
-        if key not in allowed_keys:
-            errors.append("[%s] level has unknown key %s" % (section, key))
+        key=key.lower()
+        if key not in ak:
+            errors.append("[%s] section has unknown key %s" % (section.name, key))
     return errors
 
-
 def allowed_values(section, value, allowed_values):
+    """
+    Args
+        section (ConfigParser[section])
+        value
+        allowed_values(list)
+
+    Returns list of errors (str) if section.attr contains invalid value
+    """
     errors = []
     if value not in allowed_values:
-        errors.append("[%s] unknown value %s" % (section, value))
+        errors.append("[%s] unknown value %s" % (section.name, value))
+    return errors
+
+def required_section_keys(section, required_keys):
+    """
+    Args
+        section (ConfigParser[section])
+        required_keys(list)
+
+    Returns list of errors (str) in case that section is missing certain keys
+    """
+    errors = []
+    rk = [k.lower() for k in required_keys]
+    for key in rk:
+        key=key.lower()
+        if key not in section:
+            errors.append("[%s] attribute %s is required." % (section.name, key))
     return errors

--- a/md2workflow/validation/config_validation.py
+++ b/md2workflow/validation/config_validation.py
@@ -3,6 +3,16 @@
 # Do not use from, it would trick inspect
 import md2workflow.validation as validation
 
+def validate_global_section(config):
+    errors = []
+    if not config.has_section("global"):
+        errors.append("Missing [global]. Sections %s" % config._sections)
+    else:
+        errors.extend(validation.allowed_section_keys(
+            config["global"], allowed_keys=["backend",]))
+        errors.extend(validation.required_section_keys(
+            config["global"], required_keys=["backend",]))
+    return errors
 
 def validate_config_logging(config):
     errors = []
@@ -11,4 +21,15 @@ def validate_config_logging(config):
                                                 allowed_values=("DEBUG", "ERROR", "WARNING", "INFO",)))
         errors.extend(validation.allowed_section_keys(
             config["logging"], allowed_keys=["level", ]))
+    return errors
+
+def validate_backend_config(config):
+    errors = []
+    if config["global"]["backend"] == "redmine":
+        import md2workflow.validation.redmine_validation as redmine_validation
+        errors.extend(redmine_validation.validate_redmine_section(config))
+
+    elif config["global"]["backend"] == "jira":
+        import md2workflow.validation.jira_validation as jira_validation
+        errors.extend(jira_validation.validate_jira_section(config))
     return errors

--- a/md2workflow/validation/project_validation.py
+++ b/md2workflow/validation/project_validation.py
@@ -8,7 +8,9 @@ def validate_project_section(config):
     errors = []
     if not config.has_section("project"):
         errors.append("Missing [project]. Sections %s" % config._sections)
-    if config.has_section("project"):
+    else:
         errors.extend(validation.allowed_section_keys(
-            config["project"], allowed_keys=["name", ]))
+            config["project"], allowed_keys=["name", "homepage", "short"]))
+        errors.extend(validation.required_section_keys(
+            config["project"], required_keys=["name",]))
     return errors

--- a/md2workflow/validation/project_validation.py
+++ b/md2workflow/validation/project_validation.py
@@ -10,7 +10,7 @@ def validate_project_section(config):
         errors.append("Missing [project]. Sections %s" % config._sections)
     else:
         errors.extend(validation.allowed_section_keys(
-            config["project"], allowed_keys=["name", "homepage", "short"]))
+            config["project"], allowed_keys=["name", "homepage", "identifier"]))
         errors.extend(validation.required_section_keys(
             config["project"], required_keys=["name",]))
     return errors

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
         ("share/md2workflow/config", glob("config/*"))],
     setup_requires=[] + pytest_runner,
     tests_require=["pytest",],
-    install_requires=["jira", "configparser"],
+    install_requires=["python-redmine", "jira", "configparser"],
     entry_points = {
 	"console_scripts": [
     	"md2workflow = md2workflow.cli:main",

--- a/tests/test_genericbackend.py
+++ b/tests/test_genericbackend.py
@@ -8,7 +8,13 @@ import md2workflow.workflow as workflow
 import md2workflow.backend.genericbackend as genericbackend
 import md2workflow.cli as cli
 
-"""
+
+def test_generic_objects():
+    task = workflow.GenericNestedTask(summary="Test task")
+    subtask = workflow.GenericTask(summary="Test sub task")
+    wf = workflow.GenericWorkflow(summary="Test work flow")
+    project = workflow.GenericProject(summary="Test project")
+
 def test_beta_example_generic_backend():
 
     environment_config = configparser.ConfigParser()
@@ -17,5 +23,6 @@ def test_beta_example_generic_backend():
     environment.read(environment_config)
 
     client = cli.Cli(environment, cli.CliAction.CREATE)
-    assert client.handle_project(os.path.join(cli.EXAMPLE_DIR, "release-checklist", "my_project.conf"))
-"""
+
+    # Essentially just shouldn't crash
+    client.handle_project(os.path.join(cli.EXAMPLE_DIR, "release-checklist", "my_project.conf"))

--- a/tests/test_redminebackend.py
+++ b/tests/test_redminebackend.py
@@ -10,6 +10,6 @@ import md2workflow.cli as cli
 
 def test_redmine_objects():
     task = redminebackend.RedmineTask(summary="Test task")
-    subtask = redminebackend.RedmineSubttask(summary="Test sub task")
+    subtask = redminebackend.RedmineSubtask(summary="Test sub task")
     workflow = redminebackend.RedmineBasedWorkflow(summary="Test work flow")
     project = redminebackend.RedmineBasedProject(summary="Test project")

--- a/tests/test_redminebackend.py
+++ b/tests/test_redminebackend.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+
+import configparser
+import os
+
+import md2workflow.markdown as markdown
+import md2workflow.workflow as workflow
+import md2workflow.backend.redminebackend as redminebackend
+import md2workflow.cli as cli
+
+def test_redmine_objects():
+    task = redminebackend.RedmineTask(summary="Test task")
+    subtask = redminebackend.RedmineSubttask(summary="Test sub task")
+    workflow = redminebackend.RedmineBasedWorkflow(summary="Test work flow")
+    project = redminebackend.RedmineBasedProject(summary="Test project")

--- a/tests/test_redminebackend.py
+++ b/tests/test_redminebackend.py
@@ -10,6 +10,6 @@ import md2workflow.cli as cli
 
 def test_redmine_objects():
     task = redminebackend.RedmineTask(summary="Test task")
-    subtask = redminebackend.RedmineSubtask(summary="Test sub task")
+    subtask = redminebackend.RedmineSubTask(summary="Test sub task")
     workflow = redminebackend.RedmineBasedWorkflow(summary="Test work flow")
     project = redminebackend.RedmineBasedProject(summary="Test project")


### PR DESCRIPTION
Can be executed by running:
bin/md2workflow --env config/redmine-example.conf \
example/my_project.conf

* Add backend redmine to cli.py
* Skeleton based on the generic backend
* Supply basic tests for generic backend
* Dummy tests for redmine workflow objects
  Based on generic backend
* conf file redmine-example.conf
  as of now it is the same as the local.conf