### PR TITLE
Fix redmine tests under OBS

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
     name="md2workflow",
     description="Create a JIRA or other Workflow from markdown files.",
     long_description="Create a JIRA or other Workflow from markdown files.",
-    version="1.4.15",
+    version="1.4.16",
     license="GPLv3",
     author="Lubos Kocman",
     author_email="Lubos.Kocman@suse.com",

--- a/tests/test_redmine2md.py
+++ b/tests/test_redmine2md.py
@@ -28,7 +28,9 @@ def test_headings1():
 5,My Project,action,Parent task,Status,Priority,Test task 5,lkocman,lkocman,Updated,Category,RC,Start date,Due date,Estimated time,Spent time,% Done,Created,Closed,Related issues,Private,Task 5 Description""")
 
     markdown_parser = markdown.MarkDown()
-    opts, args = redmine_csv.get_optparse().parse_args()
+    parser = redmine_csv.get_optparse()
+    parser.add_option("--ignore", action="append") # pytest injected
+    opts, args = parser.parse_args()
 
     csv_reader = csv.reader(content, dialect=csv.Dialect.doublequote)
     line_no=0


### PR DESCRIPTION
pytest was failing on extra injected --ignore option to optparse.  This is a workaround to handle it